### PR TITLE
Fix passing the tests of: spack install -v --test=root tfel mgis

### DIFF
--- a/var/spack/repos/builtin/packages/mgis/package.py
+++ b/var/spack/repos/builtin/packages/mgis/package.py
@@ -50,6 +50,7 @@ class Mgis(CMakePackage):
             values=('Debug', 'Release'))
 
     # dependencies
+    # https://thelfer.github.io/mgis/web/release-notes-2.0.html
     depends_on('tfel@4.0.0', when="@2.0")
     depends_on('tfel@3.4.3', when="@1.2.2")
     depends_on('tfel@3.4.1', when="@1.2.1")
@@ -63,6 +64,18 @@ class Mgis(CMakePackage):
     depends_on('tfel@master', when="@master")
     depends_on('boost+python+numpy', when='+python')
     extends('python', when='+python')
+
+    def patch(self):
+        """Fix the test suite to use the PYTHONPATH provided by the spack buildenv"""
+        filter_file('tests/;', 'tests:', 'bindings/python/tests/CMakeLists.txt')
+
+    def check(self):
+        """skip target 'test' which doesn't build the test programs used by tests"""
+        with working_dir(self.build_directory):
+            if self.generator == 'Unix Makefiles':
+                self._if_make_target_execute('check')
+            elif self.generator == 'Ninja':
+                self._if_ninja_target_execute('check')
 
     def cmake_args(self):
 

--- a/var/spack/repos/builtin/packages/tfel/package.py
+++ b/var/spack/repos/builtin/packages/tfel/package.py
@@ -133,6 +133,8 @@ class Tfel(CMakePackage):
 
     extends('python', when='+python_bindings')
 
+    conflicts('%gcc@:7', when='@4:')
+
     def cmake_args(self):
 
         args = []

--- a/var/spack/repos/builtin/packages/tfel/package.py
+++ b/var/spack/repos/builtin/packages/tfel/package.py
@@ -127,7 +127,9 @@ class Tfel(CMakePackage):
                type=('build', 'link', 'run'))
     depends_on('python', when='+python_bindings',
                type=('build', 'link', 'run'))
-    depends_on('boost+python+numpy', when='+python_bindings')
+    # As boost+py has py runtime dependency, boost+py needs types link and run as well:
+    depends_on('boost+python+numpy', when='+python_bindings',
+               type=('build', 'link', 'run'))
 
     extends('python', when='+python_bindings')
 
@@ -172,3 +174,11 @@ class Tfel(CMakePackage):
             args.append('-DBoost_NO_BOOST_CMAKE=ON')
 
         return args
+
+    def check(self):
+        """Skip the target 'test' which doesn't build all test programs used by tests"""
+        with working_dir(self.build_directory):
+            if self.generator == 'Unix Makefiles':
+                self._if_make_target_execute('check')
+            elif self.generator == 'Ninja':
+                self._if_ninja_target_execute('check')


### PR DESCRIPTION
In the context of my review of this pull request for spack: https://github.com/spack/spack/pull/27011:

To pass the test of: `spack install -v --test=root tfel mgis`, please apply this pull request.

It also shows that `tfel@4.0.0` fails `10930:crossed2deltachaboche_mtest` not matching expected result value,
(it does here least with gcc@11.1.0 on Ubuntu 18.04), so unless this test is ok to ignore, I'd set 3.4.3 as default.

I hope you like to merge this pull request, but of course you can ask me anything if you have questions are want changes.